### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-actions.yaml
+++ b/.github/workflows/update-actions.yaml
@@ -8,6 +8,9 @@ on:
     # Automatically run once every month
     - cron:  '0 0 1 * *'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/charl3y15/github-actions-version-updater/security/code-scanning/2](https://github.com/charl3y15/github-actions-version-updater/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/update-actions.yaml` to limit default token scope.  
Best single fix without changing behavior: set workflow-level minimal permissions (`contents: read`) so all jobs inherit least privilege unless overridden.

**Where to change:**  
- File: `.github/workflows/update-actions.yaml`  
- Insert `permissions:` after the `on:` trigger section and before `jobs:`.

**What is needed:**  
- No imports, methods, or dependencies.  
- YAML edit only:
  - `permissions:`
  - `  contents: read`

This satisfies CodeQL’s requirement and documents intended token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to enforce explicit permission restrictions, improving security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->