### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/changelog-ci.yaml
+++ b/.github/workflows/changelog-ci.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/charl3y15/github-actions-version-updater/security/code-scanning/1](https://github.com/charl3y15/github-actions-version-updater/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/changelog-ci.yaml` to enforce least privilege for the workflow.  
Best fix here is to define workflow-level permissions (applies to all jobs unless overridden), with the minimal required scope:

- `contents: read`

This directly addresses the CodeQL finding and keeps current functionality intact for checkout and typical read-only operations.  
Change location: immediately after the `on:` trigger section and before `jobs:` in `.github/workflows/changelog-ci.yaml`.

No imports, methods, or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow security configuration to restrict content access permissions to read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->